### PR TITLE
Fix clr_escape function in strict mode

### DIFF
--- a/bash_colors.sh
+++ b/bash_colors.sh
@@ -41,7 +41,7 @@ CLR_WHITEB=47           # set white background
 function clr_escape
 {
     local result="$1"
-    until [ -z "$2" ]; do
+    until [ -z "${2:-}" ]; do
 	if ! [ $2 -ge 0 -a $2 -le 47 ] 2>/dev/null; then
 	    echo "clr_escape: argument \"$2\" is out of range" >&2 && return 1
 	fi


### PR DESCRIPTION
Should solve Issue #4 where bash strict mode fails.
Tested with script

```
#!/bin/bash
set -euo pipefail
set -o errexit
set -o nounset

. ./scripts/lib/bash_colors/bash_colors.sh

clr_escape foobar $CLR_RED
```
